### PR TITLE
Update Gemfile.lock with updated gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,25 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.0.0)
-    astrolabe (1.3.0)
-      parser (>= 2.2.0.pre.3, < 3.0)
-    parser (2.2.0.3)
-      ast (>= 1.1, < 3.0)
-    powerpack (0.1.0)
-    rainbow (2.0.0)
-    rubocop (0.29.1)
-      astrolabe (~> 1.3)
-      parser (>= 2.2.0.1, < 3.0)
+    ast (2.3.0)
+    parser (2.3.2.0)
+      ast (~> 2.2)
+    powerpack (0.1.1)
+    rainbow (2.1.0)
+    rubocop (0.45.0)
+      parser (>= 2.3.1.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
-      ruby-progressbar (~> 1.4)
-    ruby-progressbar (1.7.1)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.8.1)
+    unicode-display_width (1.1.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   rubocop
+
+BUNDLED WITH
+   1.13.6


### PR DESCRIPTION
PR updates the gems used in the Docker image to primarily pull in latest Rubocop updates. Specifically this: https://github.com/bbatsov/rubocop/issues/1656

[NOTICKET]