### PR TITLE
Exluded directories from the rubo gaze

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ AllCops:
   TargetRubyVersion: 1.9
   Exclude:
     - '**/*.gemspec'
-    - 'vendor/**/*'
+    - '**/vendor/**/*'
 
 Style/SpaceBeforeFirstArg:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,8 @@
 AllCops:
   TargetRubyVersion: 1.9
   Exclude:
-    - "**/*.gemspec"
+    - '**/*.gemspec'
+    - 'vendor/**/*'
 
 Style/SpaceBeforeFirstArg:
   Enabled: false


### PR DESCRIPTION
We (WS AMP) put our git modules inside a `vendor` directory, which is currently getting scanned. This excludes that `vendor` directory and any `node_modules` directory.

[NOTICKET]